### PR TITLE
feat: add meetings list and detail pages

### DIFF
--- a/src/data/meetings.ts
+++ b/src/data/meetings.ts
@@ -1,0 +1,29 @@
+export interface Meeting {
+  id: number;
+  date: string;
+  provider: string;
+  status: string;
+  details: string;
+}
+
+export const meetings: Meeting[] = [
+  {
+    id: 1,
+    date: "2024-10-01",
+    provider: "Maison A",
+    status: "Confirmé",
+    details: "Dégustation des nouvelles cuvées.",
+  },
+  {
+    id: 2,
+    date: "2024-10-05",
+    provider: "Maison B",
+    status: "En attente",
+    details: "Présentation de la gamme 2023.",
+  },
+];
+
+export function getMeetingById(id: number): Meeting | undefined {
+  return meetings.find((m) => m.id === id);
+}
+

--- a/src/pages/admin/meetings/[id].tsx
+++ b/src/pages/admin/meetings/[id].tsx
@@ -1,5 +1,81 @@
-const MeetingDetail = () => {
-  return <h2>Fiche rendez-vous – à venir</h2>
-}
+import { useParams } from "react-router-dom";
+import { useState } from "react";
+import { getMeetingById, Meeting } from "../../../data/meetings";
 
-export default MeetingDetail
+const MeetingDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const meeting = getMeetingById(Number(id));
+  const [formData, setFormData] = useState<Meeting | undefined>(meeting);
+
+  if (!meeting || !formData) {
+    return <p>Rendez-vous introuvable.</p>;
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => (prev ? { ...prev, [name]: value } : prev));
+  };
+
+  const handleSave = () => {
+    alert("Rendez-vous modifié (simulation)");
+  };
+
+  const sendInvitation = () => {
+    alert("Invitation envoyée");
+  };
+
+  return (
+    <div>
+      <h2>Détails du rendez-vous</h2>
+      <div className="flex flex-col gap-2">
+        <label>
+          Date :
+          <input
+            name="date"
+            value={formData.date}
+            onChange={handleChange}
+            className="border ml-2"
+          />
+        </label>
+        <label>
+          Fournisseur :
+          <input
+            name="provider"
+            value={formData.provider}
+            onChange={handleChange}
+            className="border ml-2"
+          />
+        </label>
+        <label>
+          Statut :
+          <input
+            name="status"
+            value={formData.status}
+            onChange={handleChange}
+            className="border ml-2"
+          />
+        </label>
+        <label>
+          Détails :
+          <input
+            name="details"
+            value={formData.details}
+            onChange={handleChange}
+            className="border ml-2"
+          />
+        </label>
+      </div>
+      <div className="mt-4 flex gap-2">
+        <button onClick={handleSave} className="border px-2 py-1">
+          Enregistrer
+        </button>
+        <button onClick={sendInvitation} className="border px-2 py-1">
+          Envoyer l'invitation
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MeetingDetail;
+

--- a/src/pages/admin/meetings/index.tsx
+++ b/src/pages/admin/meetings/index.tsx
@@ -1,5 +1,33 @@
-const MeetingsList = () => {
-  return <h2>Tableau des rendez-vous – à venir</h2>
-}
+import { Link } from "react-router-dom";
+import { meetings } from "../../../data/meetings";
 
-export default MeetingsList
+const MeetingsList = () => {
+  return (
+    <div>
+      <h2>Tableau des rendez-vous</h2>
+      <table className="min-w-full border-collapse border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1 text-left">Date</th>
+            <th className="border px-2 py-1 text-left">Fournisseur</th>
+            <th className="border px-2 py-1 text-left">Statut</th>
+          </tr>
+        </thead>
+        <tbody>
+          {meetings.map((meeting) => (
+            <tr key={meeting.id}>
+              <td className="border px-2 py-1">
+                <Link to={`/admin/meetings/${meeting.id}`}>{meeting.date}</Link>
+              </td>
+              <td className="border px-2 py-1">{meeting.provider}</td>
+              <td className="border px-2 py-1">{meeting.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default MeetingsList;
+


### PR DESCRIPTION
## Summary
- add sample meetings data set
- list meetings in admin table
- allow editing meeting details and send invitation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any; no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_689747961aa083239e9da285f1bff6f8