### PR TITLE
feat: add live product checks endpoint

### DIFF
--- a/api/run-checks-live.ts
+++ b/api/run-checks-live.ts
@@ -1,1 +1,35 @@
 // API route pour analyser la qualité des pages produits live
+
+interface RequestLike {
+  query?: Record<string, string | string[]>;
+}
+
+interface ResponseLike {
+  status: (code: number) => ResponseLike;
+  json: (body: unknown) => void;
+}
+
+// Handler compatible Vercel
+export default async function handler(req: RequestLike, res: ResponseLike) {
+  const url = typeof req.query?.url === 'string' ? req.query.url : undefined;
+
+  if (!url) {
+    res.status(400).json({ error: 'Missing url parameter' });
+    return;
+  }
+
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+
+    const checks = {
+      hasTitle: /<title>.*<\/title>/i.test(html),
+      hasMetaDescription: /<meta[^>]+name=["']description["'][^>]*>/i.test(html),
+      hasProductSchema: /"@type"\s*:\s*"Product"/i.test(html),
+    };
+
+    res.status(200).json({ url, checks });
+  } catch (error) {
+    res.status(500).json({ error: (error as Error).message });
+  }
+}


### PR DESCRIPTION
## Summary
- expose `api/run-checks-live` Vercel handler
- fetch product page and run basic quality checks
- return JSON with check results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / unused vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68974790cc788323be6c47c28a02eae9