### PR TITLE
Add daily tasks module

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import ProductsList from './pages/admin/products/index'
 import ProductDetail from './pages/admin/products/[id]'
 import MeetingsList from './pages/admin/meetings/index'
 import MeetingDetail from './pages/admin/meetings/[id]'
+import TasksList from './pages/admin/tasks/index'
 
 const App = () => (
   <BrowserRouter>
@@ -15,10 +16,13 @@ const App = () => (
       <Route path="/admin/products/:id" element={<ProductDetail />} />
       <Route path="/admin/meetings" element={<MeetingsList />} />
       <Route path="/admin/meetings/:id" element={<MeetingDetail />} />
+      <Route path="/admin/tasks" element={<TasksList />} />
       <Route path="*" element={<h1>Bienvenue dans MANAGER</h1>} />
     </Routes>
   </BrowserRouter>
 )
+
+export default App
 
 const container = document.getElementById('root')
 const root = createRoot(container!)

--- a/src/pages/admin/tasks/index.tsx
+++ b/src/pages/admin/tasks/index.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react'
+
+type Task = {
+  id: number
+  text: string
+  completed: boolean
+}
+
+const defaultTasks: Task[] = [
+  { id: 1, text: 'Appeler les clients', completed: false },
+  { id: 2, text: 'Réviser les stocks', completed: false },
+  { id: 3, text: 'Envoyer les emails', completed: false }
+]
+
+const TasksList = () => {
+  const [tasks, setTasks] = useState<Task[]>(() => {
+    const stored = localStorage.getItem('dailyTasks')
+    return stored ? JSON.parse(stored) : defaultTasks
+  })
+
+  useEffect(() => {
+    localStorage.setItem('dailyTasks', JSON.stringify(tasks))
+  }, [tasks])
+
+  const toggleTask = (id: number) => {
+    setTasks(tasks.map(task => (task.id === id ? { ...task, completed: !task.completed } : task)))
+  }
+
+  return (
+    <div className='p-4'>
+      <h2 className='text-xl mb-4'>Tâches quotidiennes</h2>
+      <ul>
+        {tasks.map(task => (
+          <li key={task.id} className='flex items-center mb-2'>
+            <input
+              type='checkbox'
+              className='mr-2'
+              checked={task.completed}
+              onChange={() => toggleTask(task.id)}
+            />
+            <span className={task.completed ? 'line-through' : ''}>{task.text}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default TasksList


### PR DESCRIPTION
## Summary
- add daily task page with local storage persistence and checkboxes
- register route for daily tasks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/main.tsx src/pages/admin/tasks/index.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68974742f7d48323a3122cf08fcf93a8